### PR TITLE
Quick spelling fixs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export default Example;
 
 Retrieve Geo position from the browser.
 
-- `options: object`: [`PositionOtions`](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) object.
+- `options: object`: [`PositionOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) object.
 
 ### `useGeoPosition()`
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ import { useGeoPosition } from 'the-platform';
 
 const Example = () => {
   const { coords } = useGeoPosition();
-  return <div>{coords && `${cords.longitude}, ${coords.latitude}`}</div>;
+  return <div>{coords && `${coords.longitude}, ${coords.latitude}`}</div>;
 };
 
 export default Example;


### PR DESCRIPTION
Fix spelling of `PositionOtions` to `PositionOptions` and `cords` to `coords` in README