### PR TITLE
Update index export to include useMedia

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export * from './useDeviceMotion';
 export * from './useDeviceOrientation';
 export * from './useGeoPosition';
 export * from './useIntersectionObserver';
+export * from './useMedia';
 export * from './useNetworkStatus';
 export * from './useWindowScrollPosition';
 export * from './useWindowSize';


### PR DESCRIPTION
Currently, useMedia is not exported (even though it's been implemented and documented). Added default export to expose this functionality.