### PR TITLE
fix: Fire useEffect when query changes

### DIFF
--- a/src/useMedia.js
+++ b/src/useMedia.js
@@ -29,7 +29,7 @@ export function useMedia(query, defaultMatches = true) {
       active = false;
       mediaQueryList.removeListener(listener);
     };
-  }, []);
+  }, [query]);
 
   return matches;
 }


### PR DESCRIPTION
Thanks for your work, that's great. Basically, we passed in an empty array `[]` to useEffect hook, which would tells React that this useEffect would run only on mount and clean up on unmount, so it would not run when `query` updates. Please refer to [conditionally-firing-an-effect](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)

Here is a demo for this use case. https://codesandbox.io/s/m3x8my2l58 :)